### PR TITLE
Fix data point date shifting

### DIFF
--- a/backend/src/services/data-point.service.ts
+++ b/backend/src/services/data-point.service.ts
@@ -37,7 +37,8 @@ export async function createDataPointForMetric(params: {
 }) {
   const { metricId, metricValue, date = new Date() } = params;
 
-  const roundedDate = addDays(roundToStartOfDay(date), 1); 
+  // Normalize to 00:00 to avoid duplicating entries across timezones
+  const roundedDate = roundToStartOfDay(date);
 
   return await prisma.dataPoint.upsert({
     where: {


### PR DESCRIPTION
## Summary
- correct date rounding when storing data points

## Testing
- `npm run build --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687a6b31213c832eb2b266a4d9da026e